### PR TITLE
Update the updates list

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ We have a "changelog" of decisions: [CHANGELOG.md](CHANGELOG.md).
 
 These updates provide high level information about the Editorial Board's activities:
 
-- [2024-01](content/updates/2024-01-08-editorial-board-update.md)
+- [Updates](https://python.github.io/editorial-board/updates/)
 
 ## Process
 

--- a/README.md
+++ b/README.md
@@ -10,9 +10,8 @@ We have a "changelog" of decisions: [CHANGELOG.md](CHANGELOG.md).
 
 ## Updates
 
-These updates provide high level information about the Editorial Board's activities:
-
-- [Updates](https://python.github.io/editorial-board/updates/)
+[Read updates](https://python.github.io/editorial-board/updates/) of the Editorial Board's activities can be read.
+Subscribe to the updates using the [RSS feed](https://python.github.io/editorial-board/updates/index.xml).
 
 ## Process
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ We have a "changelog" of decisions: [CHANGELOG.md](CHANGELOG.md).
 
 ## Updates
 
-[Read updates](https://python.github.io/editorial-board/updates/) of the Editorial Board's activities can be read.
+[Read updates](https://python.github.io/editorial-board/updates/) of the Editorial Board's activities.
 Subscribe to the updates using the [RSS feed](https://python.github.io/editorial-board/updates/index.xml).
 
 ## Process


### PR DESCRIPTION
The list of updates on the README only shows 2024-01.

This PR replaces it with a link to https://python.github.io/editorial-board/updates/ so it doesn't need to be updated each month.

If you do want a list of all updates on the README, you could use this handy tool called [cog](https://github.com/nedbat/cog) ;)

For example: https://github.com/python/steering-council/blob/55f9ea874d247ec80e0f975901fd518f940eaf1e/Makefile#L1-L4