### PR TITLE
Add Board members as a taxonomy

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,11 @@ This will create the file under ``content/updates/newupdate.md``, and you can co
 
 (replace "newupdate.md" with the desired filename.)
 
+### Updating the Meeting Attendee List
+
+The list of attendees is pulled from the ``"members"`` field in the frontmatter. By default, it lists all members
+of the Python Docs Editorial Board. If a member did not attend the meeting, remove from this list.
+
 ## Building the static site locally
 
 1. First install Hugo.

--- a/archetypes/updates.md
+++ b/archetypes/updates.md
@@ -9,10 +9,8 @@ categories: ["minutes"]
 series: ["Meeting Minutes"]
 ShowToc: false
 TocOpen: false
+members: ["Carol Willing", "Guido van Rossum", "Joanna Jablonski", "Mariatta", "Ned Batchelder"]
 ---
-
-
-### Attendees
 
 ### Agenda
 

--- a/assets/css/extended/custom.css
+++ b/assets/css/extended/custom.css
@@ -21,3 +21,19 @@
 .breadcrumbs a:hover{
     text-decoration: underline;
 }
+
+#members {
+  display: inline;
+  list-style: none;
+}
+
+#members li {
+  display: inline;
+}
+
+#members li:after {
+  content: ", ";
+}
+#members li:last-child:after {
+    content: "";
+}

--- a/content/updates/2024-01-08-editorial-board-update.md
+++ b/content/updates/2024-01-08-editorial-board-update.md
@@ -9,13 +9,8 @@ categories: ["minutes"]
 series: ["Meeting Minutes"]
 ShowToc: false
 TocOpen: false
+members: ["Carol Willing", "Guido van Rossum", "Joanna Jablonski", "Mariatta", "Ned Batchelder"]
 ---
-
-
-
-### Attendees
-
-Carol, Guido, Joanna, Mariatta, Ned
 
 ### Agenda
 

--- a/content/updates/2024-02-12-editorial-board-update.md
+++ b/content/updates/2024-02-12-editorial-board-update.md
@@ -10,7 +10,6 @@ series: ["Meeting Minutes"]
 ShowToc: false
 TocOpen: false
 members: ["Guido van Rossum", "Joanna Jablonski", "Mariatta", "Ned Batchelder"]
-
 ---
 
 ## Agenda

--- a/content/updates/2024-02-12-editorial-board-update.md
+++ b/content/updates/2024-02-12-editorial-board-update.md
@@ -9,12 +9,9 @@ categories: ["minutes"]
 series: ["Meeting Minutes"]
 ShowToc: false
 TocOpen: false
+members: ["Guido van Rossum", "Joanna Jablonski", "Mariatta", "Ned Batchelder"]
+
 ---
-
-## Attendees
-
-Mariatta, Ned, Joanna, Guido
-
 
 ## Agenda
 

--- a/content/updates/2024-03-11-editorial-board-update.md
+++ b/content/updates/2024-03-11-editorial-board-update.md
@@ -9,13 +9,9 @@ categories: ["minutes"]
 series: ["Meeting Minutes"]
 ShowToc: false
 TocOpen: false
+members: ["Guido van Rossum", "Joanna Jablonski", "Mariatta", "Ned Batchelder"]
+
 ---
-
-
-### Attendees
-
-Mariatta, Ned, Joanna, Guido
-
 
 ### Agenda
 

--- a/content/updates/2024-03-11-editorial-board-update.md
+++ b/content/updates/2024-03-11-editorial-board-update.md
@@ -10,7 +10,6 @@ series: ["Meeting Minutes"]
 ShowToc: false
 TocOpen: false
 members: ["Guido van Rossum", "Joanna Jablonski", "Mariatta", "Ned Batchelder"]
-
 ---
 
 ### Agenda

--- a/content/updates/2024-04-08-editorial-board-update.md
+++ b/content/updates/2024-04-08-editorial-board-update.md
@@ -9,13 +9,8 @@ categories: ["minutes"]
 series: ["Meeting Minutes"]
 ShowToc: false
 TocOpen: false
+members: ["Guido van Rossum", "Joanna Jablonski", "Mariatta", "Ned Batchelder"]
 ---
-
-
-### Attendees
-
-Mariatta, Ned, Joanna, Guido
-
 
 ### Agenda
 

--- a/content/updates/2024-06-03-editorial-board-update.md
+++ b/content/updates/2024-06-03-editorial-board-update.md
@@ -9,13 +9,8 @@ categories: ["minutes"]
 series: ["Meeting Minutes"]
 ShowToc: false
 TocOpen: false
+members: ["Carol Willing", "Guido van Rossum", "Joanna Jablonski", "Mariatta", "Ned Batchelder"]
 ---
-
-
-### Attendees
-
-Mariatta, Ned, Carol, Joanna, Guido
-
 
 ### Old Action Items
 

--- a/content/updates/2024-08-12-editorial-board-update.md
+++ b/content/updates/2024-08-12-editorial-board-update.md
@@ -9,12 +9,8 @@ categories: ["minutes"]
 series: ["Meeting Minutes"]
 ShowToc: false
 TocOpen: false
+members: ["Mariatta", "Ned Batchelder"]
 ---
-
-### Attendees
-
-Mariatta, Ned
-
 
 ### Old Action Items
 

--- a/content/updates/2024-09-09-editorial-board-update.md
+++ b/content/updates/2024-09-09-editorial-board-update.md
@@ -9,15 +9,8 @@ categories: ["minutes"]
 series: ["Meeting Minutes"]
 ShowToc: false
 TocOpen: false
+members: ["Carol Willing", "Guido van Rossum", "Mariatta", "Ned Batchelder"]
 ---
-
-### Attendees
-
-* Guido
-* Mariatta
-* Carol
-* Ned
-
 
 ## Notes
 

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -84,6 +84,10 @@ menu:
       name: Search
       url: /search
       weight: 50
+    - identifier: members
+      name: Board Members
+      url: /members
+      weight: 60
 
 module:
   hugoVersion:
@@ -92,3 +96,9 @@ module:
   imports:
     - path: github.com/adityatelange/hugo-PaperMod
       disable: false
+
+taxonomies:
+  category: categories
+  tag: tags
+  series: series
+  member: members

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,0 +1,67 @@
+{{- define "main" }}
+
+<article class="post-single">
+  <header class="post-header">
+    {{ partial "breadcrumbs.html" . }}
+    <h1 class="post-title entry-hint-parent">
+      {{ .Title }}
+      {{- if .Draft }}
+      <span class="entry-hint" title="Draft">
+        <svg xmlns="http://www.w3.org/2000/svg" height="35" viewBox="0 -960 960 960" fill="currentColor">
+          <path
+            d="M160-410v-60h300v60H160Zm0-165v-60h470v60H160Zm0-165v-60h470v60H160Zm360 580v-123l221-220q9-9 20-13t22-4q12 0 23 4.5t20 13.5l37 37q9 9 13 20t4 22q0 11-4.5 22.5T862.09-380L643-160H520Zm300-263-37-37 37 37ZM580-220h38l121-122-18-19-19-18-122 121v38Zm141-141-19-18 37 37-18-19Z" />
+        </svg>
+      </span>
+      {{- end }}
+    </h1>
+    {{- if .Description }}
+    <div class="post-description">
+      {{ .Description }}
+    </div>
+    {{- end }}
+    {{- if not (.Param "hideMeta") }}
+    <div class="post-meta">
+      {{- partial "post_meta.html" . -}}
+      {{- partial "translation_list.html" . -}}
+      {{- partial "edit_post.html" . -}}
+      {{- partial "post_canonical.html" . -}}
+    </div>
+    {{- end }}
+  </header>
+  {{- partial "members.html" . }}
+
+  {{- $isHidden := (.Param "cover.hiddenInSingle") | default (.Param "cover.hidden") | default false }}
+  {{- partial "cover.html" (dict "cxt" . "IsSingle" true "isHidden" $isHidden) }}
+  {{- if (.Param "ShowToc") }}
+  {{- partial "toc.html" . }}
+  {{- end }}
+
+  {{- if .Content }}
+  <div class="post-content">
+    {{- if not (.Param "disableAnchoredHeadings") }}
+    {{- partial "anchored_headings.html" .Content -}}
+    {{- else }}in content{{ .Content }}{{ end }}
+  </div>
+  {{- end }}
+
+  <footer class="post-footer">
+    {{- $tags := .Language.Params.Taxonomies.tag | default "tags" }}
+    <ul class="post-tags">
+      {{- range ($.GetTerms $tags) }}
+      <li><a href="{{ .Permalink }}">{{ .LinkTitle }}</a></li>
+      {{- end }}
+    </ul>
+    {{- if (.Param "ShowPostNavLinks") }}
+    {{- partial "post_nav_links.html" . }}
+    {{- end }}
+    {{- if (and site.Params.ShowShareButtons (ne .Params.disableShare true)) }}
+    {{- partial "share_icons.html" . -}}
+    {{- end }}
+  </footer>
+
+  {{- if (.Param "comments") }}
+  {{- partial "comments.html" . }}
+  {{- end }}
+</article>
+
+{{- end }}{{/* end main */}}

--- a/layouts/partials/members.html
+++ b/layouts/partials/members.html
@@ -1,12 +1,12 @@
-<div class="post-content">
+<div class="post-content" id="members">
     <h3 id="attendees">Attendees</h3>
-    {{ range $member := .Param "members" }}
     <ul>
+        {{ range $member := .Param "members" }}
         <li>
             <a href="{{ `members/` | relLangURL }}{{ $member | urlize }}/">
             {{ $member }}
         </a>
         </li>
+        {{ end }}
     </ul>
-    {{ end }}
 </div>

--- a/layouts/partials/members.html
+++ b/layouts/partials/members.html
@@ -1,0 +1,12 @@
+<div class="post-content">
+    <h3 id="attendees">Attendees</h3>
+    {{ range $member := .Param "members" }}
+    <ul>
+        <li>
+            <a href="{{ `members/` | relLangURL }}{{ $member | urlize }}/">
+            {{ $member }}
+        </a>
+        </li>
+    </ul>
+    {{ end }}
+</div>


### PR DESCRIPTION
This adds a new "taxonomy" of the Editorial Board members.

# New navigation menu item
- There is now a new menu item on the top of the page: Board members
- If clicked, it will display the list of Python Editorial Board Members.
- Clicking each board members name on this page will take you to a page with all the meeting minutes in which this board member attended

## Screenshot of the menu and the "members" page.
<img width="1075" alt="Screenshot 2024-09-23 at 4 51 55 PM" src="https://github.com/user-attachments/assets/6a64f0f3-df53-42f4-9ab5-2e8acb3623fc">


# New "members" in the front matter
- Each meeting minutes now has a "members" frontmatter.
- The "Attendees" list for each meeting is pulled from the list of "members".
- The attendees are now rendered as urls. Clicking on the url takes you to a page for that board member, listing all the meeting minutes in which this board member attended.

## Screenshot of the new attendee list

<img width="900" alt="Screenshot 2024-09-23 at 4 48 23 PM" src="https://github.com/user-attachments/assets/2d4565ef-6bfd-40f3-a864-0c20cea346e1">


## Screenshot showing all the meetings that Guido attended

<img width="988" alt="Screenshot 2024-09-23 at 4 54 14 PM" src="https://github.com/user-attachments/assets/408551ea-7897-4cf0-aca8-ba8fe5d41f5e">


