### PR TITLE
Update Hugo to 0.160.1 and fix theme compatibility

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/python/editorial-board
 
 go 1.12
 
-require github.com/adityatelange/hugo-PaperMod v0.0.0-20250301152106-e2e1011bdeca // indirect
+require github.com/adityatelange/hugo-PaperMod v0.0.0-20260510052646-154d006e0182 // indirect

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -37,7 +37,7 @@
   {{- end }}
 
   {{- if .Content }}
-  <div class="post-content">
+  <div class="post-content md-content">
     {{- if not (.Param "disableAnchoredHeadings") }}
     {{- partial "anchored_headings.html" .Content -}}
     {{- else }}in content{{ .Content }}{{ end }}

--- a/layouts/changelog/list.html
+++ b/layouts/changelog/list.html
@@ -31,7 +31,7 @@
 {{- end }}
 
 {{- if .Content }}
-<div class="post-content">
+<div class="post-content md-content">
   {{- if not (.Param "disableAnchoredHeadings") }}
   {{- partial "anchored_headings.html" .Content -}}
   {{- else }}{{ .Content }}{{ end }}
@@ -101,7 +101,7 @@
   {{- end }}
 
   {{- if .Content }}
-  <div class="post-content">
+  <div class="post-content md-content">
     {{- if not (.Param "disableAnchoredHeadings") }}
     {{- partial "anchored_headings.html" .Content -}}
     {{- else }}in content{{ .Content }}{{ end }}

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@
   command = "hugo --gc --minify"
 
   [build.environment]
-    HUGO_VERSION = "0.128.0"
+    HUGO_VERSION = "0.160.1"
 
 [context.production.environment]
   HUGO_ENV           = "production"


### PR DESCRIPTION
## Summary

Local Hugo builds were broken: the pinned PaperMod theme (2025-03-01) fails to render under recent Hugo with `partial "get-page-images" not found`, while Netlify pinned the older Hugo 0.128.0. This brings the toolchain forward and keeps local and Netlify in sync.

## Changes

- **Bump Hugo** (`netlify.toml`): `HUGO_VERSION` 0.128.0 → 0.160.1, matching a current local install.
- **Bump PaperMod theme** (`go.mod`): 2025-03-01 → 2026-05-10, which is compatible with current Hugo.
- **Adapt custom layouts to the theme's `md-content` class.** PaperMod (2026-05) moved its markdown content styling from `.post-content` to a new `.md-content` class. This repo's custom `single.html` and `changelog/list.html` overrides only emitted `.post-content`, so after the bump rendered markdown lost:
  - list indentation — bullets sat outside the content margin (visible on every meeting-minutes page), and
  - the code-block background — syntax colors became unreadable on white in light mode.

  Added `md-content` alongside `post-content` on the content wrappers, matching the theme's own templates.

## Verification

`hugo --gc --minify` builds clean locally (71 pages, no errors). Meeting-minutes bullets indent correctly and code blocks render on the dark background in both light and dark mode.

## Notes

This is the foundational fix — other in-flight branches (new meeting notes, board docs) build correctly once this lands on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)