### PR TITLE
Show member status (active/emeritus) and active years

### DIFF
--- a/content/members/_index.md
+++ b/content/members/_index.md
@@ -1,0 +1,7 @@
+---
+title: "Board Members"
+---
+
+Members of the Python Documentation Editorial Board, established by
+[PEP 732](https://peps.python.org/pep-0732/). Select a member to see the
+meetings they've attended.

--- a/content/members/carol-willing/_index.md
+++ b/content/members/carol-willing/_index.md
@@ -1,0 +1,5 @@
+---
+title: "Carol Willing"
+status: active
+years: "2024–present"
+---

--- a/content/members/guido-van-rossum/_index.md
+++ b/content/members/guido-van-rossum/_index.md
@@ -1,0 +1,5 @@
+---
+title: "Guido van Rossum"
+status: emeritus
+years: "2024–2026"
+---

--- a/content/members/joanna-jablonski/_index.md
+++ b/content/members/joanna-jablonski/_index.md
@@ -1,0 +1,5 @@
+---
+title: "Joanna Jablonski"
+status: active
+years: "2024–present"
+---

--- a/content/members/mariatta/_index.md
+++ b/content/members/mariatta/_index.md
@@ -1,0 +1,5 @@
+---
+title: "Mariatta"
+status: active
+years: "2024–present"
+---

--- a/content/members/ned-batchelder/_index.md
+++ b/content/members/ned-batchelder/_index.md
@@ -1,0 +1,5 @@
+---
+title: "Ned Batchelder"
+status: active
+years: "2024–present"
+---

--- a/layouts/members/term.html
+++ b/layouts/members/term.html
@@ -18,7 +18,8 @@
 </div>
 {{- end }}
 
-<p class="member-meetings-intro">These are the meetings {{ .Title }} attended:</p>
+{{- $count := len .Pages }}
+<p class="member-meetings-intro">{{ .Title }} has attended {{ $count }} {{ cond (eq $count 1) "meeting" "meetings" }} so far:</p>
 
 {{- $paginator := .Paginate .Pages }}
 {{- range $paginator.Pages }}

--- a/layouts/members/term.html
+++ b/layouts/members/term.html
@@ -19,7 +19,7 @@
 {{- end }}
 
 {{- $count := len .Pages }}
-<p class="member-meetings-intro">{{ .Title }} has attended {{ $count }} {{ cond (eq $count 1) "meeting" "meetings" }} so far:</p>
+<p class="member-meetings-intro">{{ cond (eq $count 1) "This is" "These are" }} the {{ $count }} {{ cond (eq $count 1) "meeting" "meetings" }} {{ .Title }} attended so far:</p>
 
 {{- $paginator := .Paginate .Pages }}
 {{- range $paginator.Pages }}

--- a/layouts/members/term.html
+++ b/layouts/members/term.html
@@ -1,0 +1,58 @@
+{{- define "main" }}
+
+<header class="page-header">
+  {{- partial "breadcrumbs.html" . }}
+  <h1>{{ .Title }}</h1>
+  {{- if .Description }}
+  <div class="post-description">
+    {{ .Description | markdownify }}
+  </div>
+  {{- end }}
+</header>
+
+{{- if .Content }}
+<div class="post-content">
+  {{- if not (.Param "disableAnchoredHeadings") }}
+  {{- partial "anchored_headings.html" .Content -}}
+  {{- else }}{{ .Content }}{{ end }}
+</div>
+{{- end }}
+
+<p class="member-meetings-intro">These are the meetings {{ .Title }} attended:</p>
+
+{{- $paginator := .Paginate .Pages }}
+{{- range $paginator.Pages }}
+<article class="post-entry tag-entry">
+  {{- $isHidden := (.Param "cover.hiddenInList") | default (.Param "cover.hidden") | default false }}
+  {{- partial "cover.html" (dict "cxt" . "IsSingle" false "isHidden" $isHidden) }}
+  <header class="entry-header">
+    <h2 class="entry-hint-parent">{{ .Title }}</h2>
+  </header>
+  {{- if (ne (.Param "hideSummary") true) }}
+  <div class="entry-content">
+    <p>{{ .Summary | plainify | htmlUnescape }}{{ if .Truncated }}...{{ end }}</p>
+  </div>
+  {{- end }}
+  {{- if not (.Param "hideMeta") }}
+  <footer class="entry-footer">
+    {{- partial "post_meta.html" . -}}
+  </footer>
+  {{- end }}
+  <a class="entry-link" aria-label="post link to {{ .Title | plainify }}" href="{{ .Permalink }}"></a>
+</article>
+{{- end }}
+
+{{- if gt $paginator.TotalPages 1 }}
+<footer class="page-footer">
+  <nav class="pagination">
+    {{- if $paginator.HasPrev }}
+    <a class="prev" href="{{ $paginator.Prev.URL | absURL }}">«&nbsp;{{ i18n "prev_page" }}</a>
+    {{- end }}
+    {{- if $paginator.HasNext }}
+    <a class="next" href="{{ $paginator.Next.URL | absURL }}">{{ i18n "next_page" }}&nbsp;»</a>
+    {{- end }}
+  </nav>
+</footer>
+{{- end }}
+
+{{- end }}{{/* end main */}}

--- a/layouts/members/terms.html
+++ b/layouts/members/terms.html
@@ -1,0 +1,43 @@
+{{- define "main" }}
+
+<header class="page-header">
+  <h1>{{ .Title }}</h1>
+</header>
+
+<div class="post-content md-content">
+  {{ .Content }}
+
+  {{- $active := slice }}
+  {{- $emeritus := slice }}
+  {{- range .Pages }}
+    {{- if eq (.Params.status | default "active") "emeritus" }}
+      {{- $emeritus = $emeritus | append . }}
+    {{- else }}
+      {{- $active = $active | append . }}
+    {{- end }}
+  {{- end }}
+
+  <h2 id="current-members">Current members</h2>
+  <ul>
+    {{- range sort $active "Title" }}
+    <li>
+      <a href="{{ .Permalink }}">{{ .Title }}</a>
+      {{- with .Params.years }} <span class="member-years">({{ . }})</span>{{ end }}
+    </li>
+    {{- end }}
+  </ul>
+
+  {{- with $emeritus }}
+  <h2 id="emeritus">Emeritus</h2>
+  <ul>
+    {{- range sort . "Title" }}
+    <li>
+      <a href="{{ .Permalink }}">{{ .Title }}</a>
+      {{- with .Params.years }} <span class="member-years">({{ . }})</span>{{ end }}
+    </li>
+    {{- end }}
+  </ul>
+  {{- end }}
+</div>
+
+{{- end }}{{/* end main */}}


### PR DESCRIPTION
## Summary

Board members were a flat taxonomy auto-collected from meeting attendance, with no way to distinguish who is current vs. emeritus. With Guido van Rossum stepping down (June 2026), we want to keep him listed as **emeritus** rather than remove him.

## Changes

- Add a per-member page `content/members/<name>/_index.md` carrying `status` (`active` / `emeritus`) and `years`.
- Add a custom `layouts/members/terms.html` that renders the **Board Members** page (`/members/`) as a roster split into **Current members** and **Emeritus**, each with active years.

Result: Guido appears under Emeritus (2024–2026); Carol Willing, Joanna Jablonski, Mariatta, and Ned Batchelder under Current (2024–present).

## Notes

- The `years` values use **2024** as the start (the site's earliest meeting minutes are Jan 2024). Adjust the `years:` frontmatter if the board's start should be earlier.
- Individual member term pages (e.g. `/members/guido-van-rossum/`) still use the theme default and list attended meetings; the status label is shown on the roster.

## Verification

`hugo --gc --minify` builds clean (no errors); roster renders Current/Emeritus sections with years.