### PR TITLE
Fix deployment by updating the Hugo version

### DIFF
--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -33,7 +33,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      HUGO_VERSION: 0.128.0
+      HUGO_VERSION: 0.160.1
     steps:
       - name: Install Hugo CLI
         run: |


### PR DESCRIPTION
## Summary

The GitHub Pages deployment has failed on every push to `main` since PR #40. That PR bumped Hugo to 0.160.1 in `netlify.toml` and bumped the PaperMod pin in `go.mod`, but the Pages workflow was left at `HUGO_VERSION: 0.128.0`. The newer theme requires Hugo 0.146.0 or greater, so Netlify and local builds stayed green while Pages broke.

From the most recent failing run:

```
WARN  Module "github.com/adityatelange/hugo-PaperMod" is not compatible with this Hugo version: Min 0.146.0
ERROR => hugo v0.146.0 or greater is required for hugo-PaperMod to build
ERROR render of "404" failed: ... partial "head.html" not found
Error: error building site: render: failed to render pages: render of "home" failed ...
```

The old Hugo can't read the new theme's layout structure, so every page fails on the missing `head.html` partial.

## Changes

- `.github/workflows/hugo.yaml`: `HUGO_VERSION` 0.128.0 to 0.160.1, matching `netlify.toml`.

## Verification

- `hugo --gc --minify` builds clean from this branch: 71 pages, no errors (only pre-existing `.Language.LanguageDirection` / `.Language.LanguageCode` deprecation warnings from the theme).
- Confirmed the release asset the workflow downloads exists: `hugo_extended_0.160.1_linux-amd64.deb` returns HTTP 200.
- The Pages run on this PR is the real check, since the workflow only triggers on pushes to `main`.
